### PR TITLE
fix: bug with resource group

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -27,8 +27,9 @@ func TestRunAgentVpcOcp(t *testing.T) {
 		},
 		CloudInfoService: sharedInfoSvc,
 	})
-	options.TerraformVars = map[string]interface{}{
+	options.TerraformVars = map[string]any{
 		"ocp_entitlement": "cloud_pak",
+		"prefix":          options.Prefix,
 	}
 
 	output, err := options.RunTestConsistency()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -260,7 +260,7 @@ func TestRunAgentClassicKubernetes(t *testing.T) {
 		},
 		CloudInfoService: sharedInfoSvc,
 	})
-	options.TerraformVars = map[string]interface{}{
+	options.TerraformVars = map[string]any{
 		"datacenter": "syd01",
 		"prefix":     options.Prefix,
 	}


### PR DESCRIPTION
### Description

````hcl
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │     "Result": {
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │         "errors": [
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │             {
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │                 "code": "GENERIC_ERROR",
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │                 "message": "Resource group name must be unique in an account.",
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │                 "more_info": "n/a"
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │             }
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │         ],
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │         "trace": "837511d7-2e10-4fc0-9485-d4e2737fe334"
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │     },
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │     "RawResult": null
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │ }
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │ 
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │ 
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │   with module.resource_group.ibm_resource_group.resource_group[0],
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │   on .terraform/modules/resource_group/main.tf line 24, in resource "ibm_resource_group" "resource_group":
TestRunAgentVpcOcp 2025-08-12T05:12:20Z logger.go:67: │   24: resource "ibm_resource_group" "resource_group" {
````

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
